### PR TITLE
[✨feat]: 공통 컴포넌트 하단 NavBar 구현

### DIFF
--- a/src/components/common/BottomNavBar.tsx
+++ b/src/components/common/BottomNavBar.tsx
@@ -10,10 +10,11 @@ export default function BottomNavBar() {
   return (
     <nav className="fixed bottom-0 left-1/2 transform -translate-x-1/2 flex justify-between w-[18.75rem] h-[3.125rem] px-[3rem] items-center rounded-t-[0.5rem] bg-[#007AFD]">
       {icons.map((Icon, index) => (
-        <Icon
+        <a
           key={index}
-          className="text-white w-[1.25rem] h-[1.25rem]"
-        />
+          className="flex items-center justify-center cursor-pointer text-white w-[2.5rem] h-[2.5rem] hover:scale-110 hover:rotate-12 transition-all duration-300">
+          <Icon className="w-[1.25rem] h-[1.25rem]" />
+        </a>
       ))}
     </nav>
   );

--- a/src/components/common/BottomNavBar.tsx
+++ b/src/components/common/BottomNavBar.tsx
@@ -1,5 +1,9 @@
 import { ShoppingBasket, TvMinimalPlay, Sparkles, Binary } from 'lucide-react';
 
+/**
+ *  BottomNavBar 컴포넌트
+ * 하단 네비게이션 바를 렌더링하며, 여러 아이콘들(키트구매, 내 키트, 영상 보기, 이벤트)을 포함합니다.
+ */
 export default function BottomNavBar() {
   const icons = [ShoppingBasket, Binary, TvMinimalPlay, Sparkles];
 

--- a/src/components/common/BottomNavBar.tsx
+++ b/src/components/common/BottomNavBar.tsx
@@ -1,0 +1,16 @@
+import { ShoppingBasket, TvMinimalPlay, Sparkles, Binary } from 'lucide-react';
+
+export default function BottomNavBar() {
+  const icons = [ShoppingBasket, Binary, TvMinimalPlay, Sparkles];
+
+  return (
+    <nav className="fixed bottom-0 left-1/2 transform -translate-x-1/2 flex justify-between w-[18.75rem] h-[3.125rem] px-[3rem] items-center rounded-t-[0.5rem] bg-[#007AFD]">
+      {icons.map((Icon, index) => (
+        <Icon
+          key={index}
+          className="text-white w-[1.25rem] h-[1.25rem]"
+        />
+      ))}
+    </nav>
+  );
+}


### PR DESCRIPTION
## 📝 설명
공통 컴포넌트 하단 NavBar를 구현했습니다.
<!-- PR에 대한 설명입니다. -->

## ✅ PR 유형
- [x] 새로운 기능 추가

## 🎨 UI
![image](https://github.com/user-attachments/assets/d11b3f40-d226-4fb3-83cc-8ec604023c55)

## 🧪 레이아웃 테스트 코드
App.tsx
```
import BottomNavBar from './components/common/BottomNavBar';
function App() {
  return (
    <>
      <BottomNavBar />
    </>
  );
}
export default App;
```
## 💬 PR 포인트
현재 routes가 구성되어있지 않기에 추후 이 부분을 수정
lucid-react 사용해서 임의로 아이콘 수정하였는데 괜찮은지 봐주세요
