### PR TITLE
[✨feat]: 브래드크럼 구현

### DIFF
--- a/src/components/common/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/common/Breadcrumb/Breadcrumb.tsx
@@ -9,7 +9,7 @@ import {
   BreadcrumbSeparator,
 } from '@/components/ui/breadcrumb';
 
-import { TITLES } from './BreadcrumbTitle';
+import { titles } from '@/routes/BreadcrumbTitle';
 
 /**
  * Breadcrumb & 제목 컴포넌트
@@ -18,9 +18,9 @@ import { TITLES } from './BreadcrumbTitle';
  * @returns {JSX.Element} Breadcrumb과 제목을 렌더링하는 컴포넌트입니다.
  */
 export default function BreadcrumbAndTitle() {
-  const LOCATION = useLocation();
-  const PATH_NAMES = LOCATION.pathname.split('/').filter(Boolean);
-  const PAGE_TITLE = TITLES[PATH_NAMES[PATH_NAMES.length - 1]];
+  const location = useLocation();
+  const pathNames = location.pathname.split('/').filter(Boolean);
+  const pageTitles = titles[pathNames[pathNames.length - 1]];
 
   return (
     <div className="inline-block">
@@ -29,32 +29,32 @@ export default function BreadcrumbAndTitle() {
           <BreadcrumbItem>
             <BreadcrumbLink href="/home">Home</BreadcrumbLink>
           </BreadcrumbItem>
-          {PATH_NAMES.length > 0 && <BreadcrumbSeparator />}
-          {PATH_NAMES.map((value, index) => {
-            const TO = `/${PATH_NAMES.slice(0, index + 1).join('/')}`;
-            if (!TITLES[value]) {
+          {pathNames.length > 0 && <BreadcrumbSeparator />}
+          {pathNames.map((value, index) => {
+            const to = `/${pathNames.slice(0, index + 1).join('/')}`;
+            if (!titles[value]) {
               return null;
             }
 
-            const IS_LAST_ITEM = index === PATH_NAMES.length - 1;
+            const isLastItem = index === pathNames.length - 1;
 
             return (
               <>
                 <BreadcrumbItem>
-                  {IS_LAST_ITEM ? (
-                    <BreadcrumbPage>{TITLES[value]}</BreadcrumbPage>
+                  {isLastItem ? (
+                    <BreadcrumbPage>{titles[value]}</BreadcrumbPage>
                   ) : (
-                    <BreadcrumbLink href={TO}>{TITLES[value]}</BreadcrumbLink>
+                    <BreadcrumbLink href={to}>{titles[value]}</BreadcrumbLink>
                   )}
                 </BreadcrumbItem>
-                {index < PATH_NAMES.length - 1 && <BreadcrumbSeparator />}
+                {index < pathNames.length - 1 && <BreadcrumbSeparator />}
               </>
             );
           })}
         </BreadcrumbList>
       </BreadcrumbComponent>
 
-      <h1 className="font-bold text-[1.75rem] mt-1">{PAGE_TITLE}</h1>
+      <h1 className="font-bold text-[1.75rem] mt-2">{pageTitles}</h1>
     </div>
   );
 }

--- a/src/components/common/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/common/Breadcrumb/Breadcrumb.tsx
@@ -1,0 +1,60 @@
+import { useLocation } from 'react-router-dom';
+
+import {
+  Breadcrumb as BreadcrumbComponent,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from '@/components/ui/breadcrumb';
+
+import { TITLES } from './BreadcrumbTitle';
+
+/**
+ * Breadcrumb & 제목 컴포넌트
+ * Breadcrumb과 해당 경로에 맞는 제목을 렌더링합니다.
+ *
+ * @returns {JSX.Element} Breadcrumb과 제목을 렌더링하는 컴포넌트입니다.
+ */
+export default function BreadcrumbAndTitle() {
+  const LOCATION = useLocation();
+  const PATH_NAMES = LOCATION.pathname.split('/').filter(Boolean);
+  const PAGE_TITLE = TITLES[PATH_NAMES[PATH_NAMES.length - 1]];
+
+  return (
+    <div className="inline-block">
+      <BreadcrumbComponent>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/home">Home</BreadcrumbLink>
+          </BreadcrumbItem>
+          {PATH_NAMES.length > 0 && <BreadcrumbSeparator />}
+          {PATH_NAMES.map((value, index) => {
+            const TO = `/${PATH_NAMES.slice(0, index + 1).join('/')}`;
+            if (!TITLES[value]) {
+              return null;
+            }
+
+            const IS_LAST_ITEM = index === PATH_NAMES.length - 1;
+
+            return (
+              <>
+                <BreadcrumbItem>
+                  {IS_LAST_ITEM ? (
+                    <BreadcrumbPage>{TITLES[value]}</BreadcrumbPage>
+                  ) : (
+                    <BreadcrumbLink href={TO}>{TITLES[value]}</BreadcrumbLink>
+                  )}
+                </BreadcrumbItem>
+                {index < PATH_NAMES.length - 1 && <BreadcrumbSeparator />}
+              </>
+            );
+          })}
+        </BreadcrumbList>
+      </BreadcrumbComponent>
+
+      <h1 className="font-bold text-[1.75rem] mt-1">{PAGE_TITLE}</h1>
+    </div>
+  );
+}

--- a/src/components/common/Breadcrumb/BreadcrumbTitle.ts
+++ b/src/components/common/Breadcrumb/BreadcrumbTitle.ts
@@ -1,0 +1,12 @@
+export interface TitleMap {
+  [key: string]: string;
+}
+
+export const TITLES: TitleMap = {
+  profile: '회원정보 수정',
+  purchasehistory: '구매 내역',
+  product: '키트 상세',
+  reviews: '키트 상세',
+  payment: '주문/결제',
+  mypage: '마이페이지',
+};

--- a/src/components/ui/breadcrumb.tsx
+++ b/src/components/ui/breadcrumb.tsx
@@ -1,0 +1,115 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { ChevronRight, MoreHorizontal } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Breadcrumb = React.forwardRef<
+  HTMLElement,
+  React.ComponentPropsWithoutRef<"nav"> & {
+    separator?: React.ReactNode
+  }
+>(({ ...props }, ref) => <nav ref={ref} aria-label="breadcrumb" {...props} />)
+Breadcrumb.displayName = "Breadcrumb"
+
+const BreadcrumbList = React.forwardRef<
+  HTMLOListElement,
+  React.ComponentPropsWithoutRef<"ol">
+>(({ className, ...props }, ref) => (
+  <ol
+    ref={ref}
+    className={cn(
+      "flex flex-wrap items-center gap-1.5 break-words text-sm text-muted-foreground sm:gap-2.5",
+      className
+    )}
+    {...props}
+  />
+))
+BreadcrumbList.displayName = "BreadcrumbList"
+
+const BreadcrumbItem = React.forwardRef<
+  HTMLLIElement,
+  React.ComponentPropsWithoutRef<"li">
+>(({ className, ...props }, ref) => (
+  <li
+    ref={ref}
+    className={cn("inline-flex items-center gap-1.5", className)}
+    {...props}
+  />
+))
+BreadcrumbItem.displayName = "BreadcrumbItem"
+
+const BreadcrumbLink = React.forwardRef<
+  HTMLAnchorElement,
+  React.ComponentPropsWithoutRef<"a"> & {
+    asChild?: boolean
+  }
+>(({ asChild, className, ...props }, ref) => {
+  const Comp = asChild ? Slot : "a"
+
+  return (
+    <Comp
+      ref={ref}
+      className={cn("transition-colors hover:text-foreground", className)}
+      {...props}
+    />
+  )
+})
+BreadcrumbLink.displayName = "BreadcrumbLink"
+
+const BreadcrumbPage = React.forwardRef<
+  HTMLSpanElement,
+  React.ComponentPropsWithoutRef<"span">
+>(({ className, ...props }, ref) => (
+  <span
+    ref={ref}
+    role="link"
+    aria-disabled="true"
+    aria-current="page"
+    className={cn("font-normal text-foreground", className)}
+    {...props}
+  />
+))
+BreadcrumbPage.displayName = "BreadcrumbPage"
+
+const BreadcrumbSeparator = ({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"li">) => (
+  <li
+    role="presentation"
+    aria-hidden="true"
+    className={cn("[&>svg]:w-3.5 [&>svg]:h-3.5", className)}
+    {...props}
+  >
+    {children ?? <ChevronRight />}
+  </li>
+)
+BreadcrumbSeparator.displayName = "BreadcrumbSeparator"
+
+const BreadcrumbEllipsis = ({
+  className,
+  ...props
+}: React.ComponentProps<"span">) => (
+  <span
+    role="presentation"
+    aria-hidden="true"
+    className={cn("flex h-9 w-9 items-center justify-center", className)}
+    {...props}
+  >
+    <MoreHorizontal className="h-4 w-4" />
+    <span className="sr-only">More</span>
+  </span>
+)
+BreadcrumbEllipsis.displayName = "BreadcrumbElipssis"
+
+export {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  BreadcrumbEllipsis,
+}

--- a/src/routes/BreadcrumbTitle.ts
+++ b/src/routes/BreadcrumbTitle.ts
@@ -2,7 +2,7 @@ export interface TitleMap {
   [key: string]: string;
 }
 
-export const TITLES: TitleMap = {
+export const titles: TitleMap = {
   profile: '회원정보 수정',
   purchasehistory: '구매 내역',
   product: '키트 상세',


### PR DESCRIPTION
## 📝 설명
공통컴포넌트 브래드크럼 구현했습니다.

## ✅ PR 유형

- [x] 새로운 기능 추가

## 💻 작업 내용


## 🎨 UI

- 기본
![image](https://github.com/user-attachments/assets/77ec98b8-ec98-4f21-8db5-cb46d03c163b)


- 마이페이지에 마우스 hover 시
![image](https://github.com/user-attachments/assets/9b2e613e-589e-4f8e-ab85-69bac6c1acba)


 
## 🧪 레이아웃 테스트 코드
App.tsx
```
import React from 'react';
import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
import BreadcrumbAndTitle from '@/components/common/Breadcrumb/Breadcrumb';

export default function App() {
  return (
    <Router>
      <div>
        <BreadcrumbAndTitle />
        {/*테스트 경로 */}
        <Routes>
          <Route path="/" />
          <Route path="/home" />
          <Route path="/mypage" />
          <Route path="/mypage/:userId/purchasehistory" />
          <Route path="/product/:productId" />
          <Route path="/product/:productId/reviews" />
          <Route path="/payment/:orderId" />
        </Routes>
      </div>
    </Router>
  );
}
```
## 💬 PR 포인트
url을 사용하여 breadcrumb을 구현하였습니다.
BreadcrumbTitle.ts에서 url 요소에 따라 보여질 제목, 브레드크럼을 정할 수 있습니다.

