### PR TITLE
[♻️refactor]: 로고 공통 컴포넌트화 및 헤더 컴포넌트 간단한 기능 추가

### DIFF
--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -1,5 +1,5 @@
 import { CircleHelp, CircleUserRound, Menu, MoonStar, X } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { ADDITIONAL_MENU_ITEMS, MENU_ITEMS } from '@/constants/header';
 
@@ -13,66 +13,83 @@ import Logo from '../Logo/Logo';
 export default function Header() {
   const icons = [MoonStar, CircleHelp, CircleUserRound];
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [isScroll, setIsScroll] = useState(false);
 
   const toggleMenu = () => {
     setIsMenuOpen(!isMenuOpen);
   };
 
+  useEffect(() => {
+    const handleScroll = () => {
+      if (isScroll && window.scrollY != 0) return;
+
+      setIsScroll(window.scrollY != 0);
+    };
+
+    handleScroll();
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, [isScroll]);
+
   return (
-    <header className="flex justify-between items-center w-pageWidth h-[3.75rem] whitespace-nowrap px-5 sticky top-0 z-header">
-      <div className="flex">
-        <Logo style="w-[8.125rem] h-[3.75rem]" />
+    <div
+      className={`flex sticky justify-center w-full top-0 z-header bg-white px-5 ${isScroll ? 'border-b border-gray-300' : ''} `}>
+      <header
+        className={`flex justify-between items-center w-pageWidth h-[3.75rem] whitespace-nowrap `}>
+        <div className="flex">
+          <Logo style="w-[8.125rem] h-[3.75rem]" />
 
-        <nav className="flex items-center h-[3.75rem] ">
-          {MENU_ITEMS.map((item, index) => (
-            <span
-              key={index}
-              className="hidden px-4 py-2 text-sm font-bold rounded cursor-pointer md:block hover:bg-gray-100">
-              {item}
-            </span>
-          ))}
-        </nav>
-      </div>
+          <nav className="flex items-center h-[3.75rem] ">
+            {MENU_ITEMS.map((item, index) => (
+              <span
+                key={index}
+                className="hidden px-4 py-2 text-sm font-bold rounded cursor-pointer md:block hover:bg-gray-100">
+                {item}
+              </span>
+            ))}
+          </nav>
+        </div>
 
-      <div className="flex items-center space-x-6">
-        {icons.map((Icon, index) => (
-          <Icon
-            key={index}
-            className="hidden md:block w-[1.5rem] h-[1.5rem] cursor-pointer hover:text-gray-500 transition duration-300"
-          />
-        ))}
-        {isMenuOpen ? (
-          <X
-            onClick={toggleMenu}
-            className="md:hidden w-[1.5rem] h-[1.5rem] cursor-pointer hover:text-gray-500 transition duration-300"
-          />
-        ) : (
-          <Menu
-            onClick={toggleMenu}
-            className="md:hidden w-[1.5rem] h-[1.5rem] cursor-pointer hover:text-gray-500 transition duration-300 "
-          />
-        )}
-      </div>
+        <div className="flex items-center space-x-6">
+          {icons.map((Icon, index) => (
+            <Icon
+              key={index}
+              className="hidden md:block w-[1.5rem] h-[1.5rem] cursor-pointer hover:text-gray-500 transition duration-300"
+            />
+          ))}
+          {isMenuOpen ? (
+            <X
+              onClick={toggleMenu}
+              className="md:hidden w-[1.5rem] h-[1.5rem] cursor-pointer hover:text-gray-500 transition duration-300"
+            />
+          ) : (
+            <Menu
+              onClick={toggleMenu}
+              className="md:hidden w-[1.5rem] h-[1.5rem] cursor-pointer hover:text-gray-500 transition duration-300 "
+            />
+          )}
+        </div>
 
-      <div
-        className={`absolute top-[3.75rem] left-0 w-full h-full bg-white shadow-md transition-max-height duration-500 ease overflow-hidden  ${isMenuOpen ? 'max-h-screen' : 'max-h-0'}`}>
-        <nav className="flex flex-col items-start p-4 mx-4 space-y-2 transform">
-          {MENU_ITEMS.map((item, index) => (
-            <span
-              key={index}
-              className="w-full px-4 py-2 text-sm font-bold text-left rounded cursor-pointer hover:bg-gray-100">
-              {item}
-            </span>
-          ))}
-          {ADDITIONAL_MENU_ITEMS.map((item, index) => (
-            <span
-              key={index}
-              className="w-full px-4 py-2 text-sm font-bold text-left rounded cursor-pointer hover:bg-gray-100">
-              {item}
-            </span>
-          ))}
-        </nav>
-      </div>
-    </header>
+        <div
+          className={`absolute top-[3.75rem] left-0 w-full h-full bg-white shadow-md transition-max-height duration-500 ease overflow-hidden  ${isMenuOpen ? 'max-h-screen' : 'max-h-0'}`}>
+          <nav className="flex flex-col items-start p-4 mx-4 space-y-2 transform">
+            {MENU_ITEMS.map((item, index) => (
+              <span
+                key={index}
+                className="w-full px-4 py-2 text-sm font-bold text-left rounded cursor-pointer hover:bg-gray-100">
+                {item}
+              </span>
+            ))}
+            {ADDITIONAL_MENU_ITEMS.map((item, index) => (
+              <span
+                key={index}
+                className="w-full px-4 py-2 text-sm font-bold text-left rounded cursor-pointer hover:bg-gray-100">
+                {item}
+              </span>
+            ))}
+          </nav>
+        </div>
+      </header>
+    </div>
   );
 }

--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -1,12 +1,15 @@
-import { MoonStar, CircleUserRound, CircleHelp, Menu, X } from 'lucide-react';
-import logo from '@/assets/logo.svg';
-import { MENU_ITEMS, ADDITIONAL_MENU_ITEMS } from '@/constants/header';
+import { CircleHelp, CircleUserRound, Menu, MoonStar, X } from 'lucide-react';
 import { useState } from 'react';
+
+import { ADDITIONAL_MENU_ITEMS, MENU_ITEMS } from '@/constants/header';
+
+import Logo from '../Logo/Logo';
 
 /**
  * Header 컴포넌트.
  * 상단 네비게이션 바를 렌더링하며, 로고와 텍스트 메뉴(키트 구매, 내 키트, 키트 영상, 프로모션, 로그인), 아이콘(다크모드, 고객 관리, 마이페이지)을 포함합니다.
  */
+
 export default function Header() {
   const icons = [MoonStar, CircleHelp, CircleUserRound];
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -16,19 +19,15 @@ export default function Header() {
   };
 
   return (
-    <header className="flex justify-between items-center  w-auto h-[3.75rem] whitespace-nowrap px-5 md:px-[10rem]">
+    <header className="flex justify-between items-center w-pageWidth h-[3.75rem] whitespace-nowrap px-5 sticky top-0 z-header">
       <div className="flex">
-        <img
-          src={logo}
-          alt="Logo"
-          className="w-[8.125rem] h-[3.75rem] cursor-pointer"
-        />
+        <Logo style="w-[8.125rem] h-[3.75rem]" />
 
         <nav className="flex items-center h-[3.75rem] ">
           {MENU_ITEMS.map((item, index) => (
             <span
               key={index}
-              className="hidden md:block text-sm font-bold cursor-pointer hover:bg-gray-100 px-4 py-2 rounded">
+              className="hidden px-4 py-2 text-sm font-bold rounded cursor-pointer md:block hover:bg-gray-100">
               {item}
             </span>
           ))}
@@ -57,18 +56,18 @@ export default function Header() {
 
       <div
         className={`absolute top-[3.75rem] left-0 w-full h-full bg-white shadow-md transition-max-height duration-500 ease overflow-hidden  ${isMenuOpen ? 'max-h-screen' : 'max-h-0'}`}>
-        <nav className="flex flex-col mx-4 items-start p-4 space-y-2 transform">
+        <nav className="flex flex-col items-start p-4 mx-4 space-y-2 transform">
           {MENU_ITEMS.map((item, index) => (
             <span
               key={index}
-              className="text-sm font-bold cursor-pointer hover:bg-gray-100 px-4 py-2 rounded w-full text-left">
+              className="w-full px-4 py-2 text-sm font-bold text-left rounded cursor-pointer hover:bg-gray-100">
               {item}
             </span>
           ))}
           {ADDITIONAL_MENU_ITEMS.map((item, index) => (
             <span
               key={index}
-              className="text-sm font-bold cursor-pointer hover:bg-gray-100 px-4 py-2 rounded w-full text-left">
+              className="w-full px-4 py-2 text-sm font-bold text-left rounded cursor-pointer hover:bg-gray-100">
               {item}
             </span>
           ))}

--- a/src/components/common/Logo/Logo.tsx
+++ b/src/components/common/Logo/Logo.tsx
@@ -1,0 +1,17 @@
+import { cn } from '@/lib/utils';
+
+interface LogoProps {
+  style: string;
+}
+
+export default function Logo({ style }: LogoProps) {
+  return (
+    <>
+      <img
+        src={'src/assets/logo.svg'}
+        alt="HiCoding-Logo"
+        className={cn(style, 'cursor-pointer')}
+      />
+    </>
+  );
+}

--- a/src/components/common/Logo/Logo.tsx
+++ b/src/components/common/Logo/Logo.tsx
@@ -1,3 +1,5 @@
+import { useNavigate } from 'react-router';
+
 import { cn } from '@/lib/utils';
 
 interface LogoProps {
@@ -5,11 +7,14 @@ interface LogoProps {
 }
 
 export default function Logo({ style }: LogoProps) {
+  const navigate = useNavigate();
+
   return (
     <>
       <img
         src={'src/assets/logo.svg'}
         alt="HiCoding-Logo"
+        onClick={() => navigate('/')}
         className={cn(style, 'cursor-pointer')}
       />
     </>

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -36,13 +36,13 @@ export default function HomePage() {
   };
 
   return (
-    <main className="absolute flex flex-col items-center w-full">
+    <main className="flex flex-col items-center w-full">
       <section className="w-full">
         <div className="relative h-screen ">
           <img
             src={'src/assets/HomeBackground/HomeBackground.png'}
             alt="HomeBackground"
-            className="absolute object-cover w-full h-full opacity-50 mt-[80px]"
+            className="absolute object-cover w-full h-full opacity-50"
           />
           <div className="absolute -translate-x-1/2 left-1/2 top-[24%]">
             {title.map((text, index) => (

--- a/src/pages/Layout/Layout.tsx
+++ b/src/pages/Layout/Layout.tsx
@@ -9,7 +9,7 @@ interface LayoutProps {
 export function Layout({ showHeader }: LayoutProps) {
   return (
     <div
-      className={`relative flex flex-col items-center w-screen h-screen max-w-full ${
+      className={`relative flex flex-col items-center w-screen max-w-full ${
         !showHeader && 'justify-center'
       }`}>
       {showHeader && <Header />}

--- a/src/pages/Layout/Layout.tsx
+++ b/src/pages/Layout/Layout.tsx
@@ -9,7 +9,7 @@ interface LayoutProps {
 export function Layout({ showHeader }: LayoutProps) {
   return (
     <div
-      className={`relative flex flex-col items-center w-screen max-w-full ${
+      className={`relative flex flex-col items-center w-screen max-w-full h-screen ${
         !showHeader && 'justify-center'
       }`}>
       {showHeader && <Header />}

--- a/src/pages/LoginPage/AuthOverlay.tsx
+++ b/src/pages/LoginPage/AuthOverlay.tsx
@@ -1,3 +1,4 @@
+import Logo from '@/components/common/Logo/Logo';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { OverlayProps } from '@/types/auth';
@@ -18,11 +19,7 @@ const OverlayContent = ({
       'absolute flex flex-col items-center justify-center w-1/2 h-full px-10 text-center transition-transform ',
       isSignIn ? ' left-0 ' : 'right-0 '
     )}>
-    <img
-      src={'src/assets/logo.svg'}
-      alt="logo"
-      className="w-[280px] h-[280px] top-8 mb-40 "
-    />
+    <Logo style="w-[280px] h-[280px] top-8 mb-40" />
     <Button
       variant="outline"
       onClick={() => onToggle(!isSignIn)}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,6 +8,9 @@ export default {
       md: '1140px',
     },
     extend: {
+      zIndex: {
+        header: '50',
+      },
       borderRadius: {
         lg: 'var(--radius)',
         md: 'calc(var(--radius) - 2px)',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,6 +8,9 @@ export default {
       md: '1140px',
     },
     extend: {
+      width: {
+        pageWidth: '1140px',
+      },
       zIndex: {
         header: '50',
       },


### PR DESCRIPTION
## 📝 설명
여러 페이지에서 사용되던 img-로고 태그를 공통 컴포넌트화 하여 적용시킬 수 있게끔 수정하였습니다.
추가로 헤더 컴포넌트에 간단한 기능들을 부여하였습니다.
<!-- PR에 대한 설명입니다. -->

## ✅ PR 유형

<!--
	팀원이 어떤 작업을 하였는지 쉽게 알아볼 수 있게 도와주는 부분입니다.
-->

- [x] 새로운 기능 추가
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 코드 리팩토링
- [ ] 파일 혹은 폴더명 수정 / 삭제
- [ ] 기타

## 💻 작업 내용
- img 태그로 사용되던 로고를 컴포넌트화
- 로고 컴포넌트로 img 태그를 교체
- 로고 클릭 시 홈으로 이동
- 스크롤 내릴 시 헤더 하단에 bottom-b 추가
- 헤더 컴포넌트 sticky 기능 추가
<!-- PR 본문을 입력하세요. -->

## 💬 PR 포인트

<!-- PR 리뷰 시 공유 사항 또는 유심히 보면 좋을 부분을 설명합니다. -->
