### PR TITLE
주문 목록 페이지 구현

### DIFF
--- a/src/pages/OrderList/OrderData.tsx
+++ b/src/pages/OrderList/OrderData.tsx
@@ -1,3 +1,28 @@
-export default function OrderData() {
-  return <div className="w-[750px] h-[150px] border-2 border-blue-500"></div>;
+import { formatOrderDate } from '@/utils/formatDate';
+
+import { IOrderData } from './type';
+
+export default function OrderData({ orderDate, orderItemList }: IOrderData) {
+  return (
+    <section className="w-[750px] h-[180px]  my-4 bg-white border border-gray-200 rounded-lg shadow-md p-4">
+      <h3 className="mb-4 text-xl font-bold">
+        {formatOrderDate(orderDate)} 주문
+      </h3>
+
+      <div className="flex">
+        <img
+          src=""
+          alt="Kit-Image"
+          className="w-[100px] h-[100px] border-2"
+        />
+        <div className="flex flex-col justify-around ml-4">
+          <span className="text-lg font-bold">{orderItemList[0].itemName}</span>
+          <span className="text-gray-700">
+            {orderItemList[0].totalPrice / orderItemList[0].itemCount} 원 ·{' '}
+            {orderItemList[0].itemCount}개
+          </span>
+        </div>
+      </div>
+    </section>
+  );
 }

--- a/src/pages/OrderList/OrderData.tsx
+++ b/src/pages/OrderList/OrderData.tsx
@@ -1,0 +1,3 @@
+export default function OrderData() {
+  return <div className="w-[750px] h-[150px] border-2 border-blue-500"></div>;
+}

--- a/src/pages/OrderList/OrderData.tsx
+++ b/src/pages/OrderList/OrderData.tsx
@@ -4,7 +4,7 @@ import { IOrderData } from './type';
 
 export default function OrderData({ orderDate, orderItemList }: IOrderData) {
   return (
-    <section className="w-[750px] h-[180px]  my-4 bg-white border border-gray-200 rounded-lg shadow-md p-4">
+    <section className="w-[750px] h-[180px]  mb-8 bg-white border border-gray-200 rounded-lg shadow-md p-4">
       <h3 className="mb-4 text-xl font-bold">
         {formatOrderDate(orderDate)} 주문
       </h3>
@@ -15,7 +15,7 @@ export default function OrderData({ orderDate, orderItemList }: IOrderData) {
           alt="Kit-Image"
           className="w-[100px] h-[100px] border-2"
         />
-        <div className="flex flex-col justify-around ml-4">
+        <div className="flex flex-col justify-around mb-4 ml-6">
           <span className="text-lg font-bold">{orderItemList[0].itemName}</span>
           <span className="text-gray-700">
             {orderItemList[0].totalPrice / orderItemList[0].itemCount} 원 ·{' '}

--- a/src/pages/OrderList/OrderList.tsx
+++ b/src/pages/OrderList/OrderList.tsx
@@ -1,5 +1,4 @@
 import { useQuery } from '@tanstack/react-query';
-import { AxiosResponse } from 'axios';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router';
 
@@ -12,22 +11,7 @@ import { API_AUTHORITY, API_ENDPOINT } from '@/services/apiEndpoint';
 import { axiosInstance } from '@/services/axiosInstance';
 
 import OrderData from './OrderData';
-
-interface IOrderItemListData {
-  itemCount: number;
-  itemId: number;
-  itemName: string;
-  totalPrice: number;
-}
-
-interface IOrderListData {
-  orderAmount: number;
-  orderDate: string;
-  orderId: number;
-  orderItemList: IOrderItemListData[];
-}
-
-type OrderListResponse = AxiosResponse<IOrderListData[]>;
+import { OrderListResponse } from './type';
 
 const DUMMY_SIDEBAR_DATA = [
   { name: '프로필', url: '/profile' },
@@ -73,18 +57,10 @@ export default function OrderList() {
     getOrderList();
   }, []);
 
-  /**
-    구조의 경우, pr에 올라온 프로필 페이지
-
-    네모 규격: w: 750, h: 150
-    네모 디자인의 경우, orderPage 참고.
-   */
-
   return (
     <>
       <BreadcrumbAndTitle />
-      {/* <div className="w-full max-w-[1140px] flex justify-between gap-16 mt-2 p-4"> */}
-      <div className="flex w-[1140px] border-2 border-red-500">
+      <div className="flex w-[1140px] border-2 border-red-500 mb-24">
         <main className="flex-1">
           {isLoading ? (
             <div className="flex justify-center">
@@ -92,9 +68,19 @@ export default function OrderList() {
             </div>
           ) : (
             <>
-              {orderList?.map((data, idx) => {
-                return <OrderData key={idx} />;
-              })}
+              {orderList?.map(
+                ({ orderAmount, orderDate, orderId, orderItemList }, idx) => {
+                  return (
+                    <OrderData
+                      key={idx}
+                      orderAmount={orderAmount}
+                      orderDate={orderDate}
+                      orderId={orderId}
+                      orderItemList={orderItemList}
+                    />
+                  );
+                }
+              )}
             </>
           )}
         </main>

--- a/src/pages/OrderList/OrderList.tsx
+++ b/src/pages/OrderList/OrderList.tsx
@@ -30,6 +30,10 @@ const DUMMY_SIDEBAR_DATA = [
   { name: '프로필', url: '/profile' },
   { name: '회원 정보 수정', url: '/profile/edit' },
   { name: '로그아웃', url: '/logout' },
+  { name: '프로필', url: '/profile' },
+  { name: '회원 정보 수정', url: '/profile/edit' },
+  { name: '로그아웃', url: '/logout' },
+  { name: '프로필', url: '/profile' },
 ];
 
 export default function OrderList() {
@@ -80,7 +84,7 @@ export default function OrderList() {
             return <OrderData key={idx} />;
           })}
         </main>
-        <aside className="h-auto w-[12rem] whitespace-nowrap">
+        <aside className="w-[12rem] whitespace-nowrap sticky top-[80px] h-fit">
           <SideBar menuItems={DUMMY_SIDEBAR_DATA} />
         </aside>
       </div>

--- a/src/pages/OrderList/OrderList.tsx
+++ b/src/pages/OrderList/OrderList.tsx
@@ -1,10 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
 import { AxiosResponse } from 'axios';
 import { useEffect } from 'react';
+import { useNavigate } from 'react-router';
 
 import BreadcrumbAndTitle from '@/components/common/Breadcrumb/BreadcrumbAndTitle';
 import SideBar from '@/components/common/SideBar';
+import Spinner from '@/components/common/Spinner/Spinner';
 import { LOCAL_STORAGE_AUTH_TOKEN } from '@/constants/localStorageKey';
+import { PATH } from '@/routes/path';
 import { API_AUTHORITY, API_ENDPOINT } from '@/services/apiEndpoint';
 import { axiosInstance } from '@/services/axiosInstance';
 
@@ -37,22 +40,31 @@ const DUMMY_SIDEBAR_DATA = [
 ];
 
 export default function OrderList() {
+  const navigate = useNavigate();
+
   const getOrderList = async () => {
-    const token = localStorage.getItem(LOCAL_STORAGE_AUTH_TOKEN);
+    try {
+      const token = localStorage.getItem(LOCAL_STORAGE_AUTH_TOKEN);
 
-    const res: OrderListResponse = await axiosInstance.get(
-      `${API_AUTHORITY.USER}${API_ENDPOINT.ORDER.ORDER_LIST}`,
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
+      const res: OrderListResponse = await axiosInstance.get(
+        `${API_AUTHORITY.USER}${API_ENDPOINT.ORDER.ORDER_LIST}`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      );
+
+      return res?.data;
+    } catch (error) {
+      if (error) {
+        alert('주문 목록을 불러오는데 실패했습니다.');
+        navigate(PATH.PROFILE);
       }
-    );
-
-    return res.data;
+    }
   };
 
-  const { data: orderList } = useQuery({
+  const { data: orderList, isLoading } = useQuery({
     queryKey: ['orderList'],
     queryFn: getOrderList,
   });
@@ -74,15 +86,17 @@ export default function OrderList() {
       {/* <div className="w-full max-w-[1140px] flex justify-between gap-16 mt-2 p-4"> */}
       <div className="flex w-[1140px] border-2 border-red-500">
         <main className="flex-1">
-          {orderList.map((data, idx) => {
-            return <OrderData key={idx} />;
-          })}
-          {orderList.map((data, idx) => {
-            return <OrderData key={idx} />;
-          })}
-          {orderList.map((data, idx) => {
-            return <OrderData key={idx} />;
-          })}
+          {isLoading ? (
+            <div className="flex justify-center">
+              <Spinner />
+            </div>
+          ) : (
+            <>
+              {orderList?.map((data, idx) => {
+                return <OrderData key={idx} />;
+              })}
+            </>
+          )}
         </main>
         <aside className="w-[12rem] whitespace-nowrap sticky top-[80px] h-fit">
           <SideBar menuItems={DUMMY_SIDEBAR_DATA} />

--- a/src/pages/OrderList/OrderList.tsx
+++ b/src/pages/OrderList/OrderList.tsx
@@ -2,6 +2,8 @@ import { useQuery } from '@tanstack/react-query';
 import { AxiosResponse } from 'axios';
 import { useEffect } from 'react';
 
+import BreadcrumbAndTitle from '@/components/common/Breadcrumb/BreadcrumbAndTitle';
+import SideBar from '@/components/common/SideBar';
 import { LOCAL_STORAGE_AUTH_TOKEN } from '@/constants/localStorageKey';
 import { API_AUTHORITY, API_ENDPOINT } from '@/services/apiEndpoint';
 import { axiosInstance } from '@/services/axiosInstance';
@@ -60,5 +62,20 @@ export default function OrderList() {
     네모 디자인의 경우, orderPage 참고.
    */
 
-  return <></>;
+  return (
+    <>
+      <BreadcrumbAndTitle />
+      {/* <div className="w-full max-w-[1140px] flex justify-between gap-16 mt-2 p-4"> */}
+      <div className="flex w-[1140px] border-2 border-red-500">
+        <main className="flex-1">
+          <div className="w-[750px] h-[150px] border-2 border-blue-500"></div>
+          <div className="w-[750px] h-[150px] border-2 border-blue-500"></div>
+          <div className="w-[750px] h-[150px] border-2 border-blue-500"></div>
+        </main>
+        <aside className="h-auto w-[12rem] whitespace-nowrap">
+          <SideBar menuItems={DUMMY_SIDEBAR_DATA} />
+        </aside>
+      </div>
+    </>
+  );
 }

--- a/src/pages/OrderList/OrderList.tsx
+++ b/src/pages/OrderList/OrderList.tsx
@@ -53,7 +53,7 @@ export default function OrderList() {
   return (
     <>
       <BreadcrumbAndTitle />
-      <div className="flex w-[1140px] border-2">
+      <div className="flex w-[1140px] mt-2">
         <main className="flex-1">
           {isLoading ? (
             <div className="flex justify-center">

--- a/src/pages/OrderList/OrderList.tsx
+++ b/src/pages/OrderList/OrderList.tsx
@@ -8,6 +8,8 @@ import { LOCAL_STORAGE_AUTH_TOKEN } from '@/constants/localStorageKey';
 import { API_AUTHORITY, API_ENDPOINT } from '@/services/apiEndpoint';
 import { axiosInstance } from '@/services/axiosInstance';
 
+import OrderData from './OrderData';
+
 interface IOrderItemListData {
   itemCount: number;
   itemId: number;
@@ -68,9 +70,15 @@ export default function OrderList() {
       {/* <div className="w-full max-w-[1140px] flex justify-between gap-16 mt-2 p-4"> */}
       <div className="flex w-[1140px] border-2 border-red-500">
         <main className="flex-1">
-          <div className="w-[750px] h-[150px] border-2 border-blue-500"></div>
-          <div className="w-[750px] h-[150px] border-2 border-blue-500"></div>
-          <div className="w-[750px] h-[150px] border-2 border-blue-500"></div>
+          {orderList.map((data, idx) => {
+            return <OrderData key={idx} />;
+          })}
+          {orderList.map((data, idx) => {
+            return <OrderData key={idx} />;
+          })}
+          {orderList.map((data, idx) => {
+            return <OrderData key={idx} />;
+          })}
         </main>
         <aside className="h-auto w-[12rem] whitespace-nowrap">
           <SideBar menuItems={DUMMY_SIDEBAR_DATA} />

--- a/src/pages/OrderList/OrderList.tsx
+++ b/src/pages/OrderList/OrderList.tsx
@@ -6,13 +6,13 @@ import BreadcrumbAndTitle from '@/components/common/Breadcrumb/BreadcrumbAndTitl
 import SideBar from '@/components/common/SideBar';
 import Spinner from '@/components/common/Spinner/Spinner';
 import { LOCAL_STORAGE_AUTH_TOKEN } from '@/constants/localStorageKey';
-import { PATH } from '@/routes/path';
 import { API_AUTHORITY, API_ENDPOINT } from '@/services/apiEndpoint';
 import { axiosInstance } from '@/services/axiosInstance';
 
 import OrderData from './OrderData';
 import { OrderListResponse } from './type';
 
+// ! 공통 컴포넌트 - SideBar 변경 후 더미데이터 제거 예정
 const DUMMY_SIDEBAR_DATA = [
   { name: '프로필', url: '/profile' },
   { name: '회원 정보 수정', url: '/profile/edit' },
@@ -27,25 +27,18 @@ export default function OrderList() {
   const navigate = useNavigate();
 
   const getOrderList = async () => {
-    try {
-      const token = localStorage.getItem(LOCAL_STORAGE_AUTH_TOKEN);
+    const token = localStorage.getItem(LOCAL_STORAGE_AUTH_TOKEN);
 
-      const res: OrderListResponse = await axiosInstance.get(
-        `${API_AUTHORITY.USER}${API_ENDPOINT.ORDER.ORDER_LIST}`,
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        }
-      );
-
-      return res?.data;
-    } catch (error) {
-      if (error) {
-        alert('주문 목록을 불러오는데 실패했습니다.');
-        navigate(PATH.PROFILE);
+    const res: OrderListResponse = await axiosInstance.get(
+      `${API_AUTHORITY.USER}${API_ENDPOINT.ORDER.ORDER_LIST}`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
       }
-    }
+    );
+
+    return res?.data;
   };
 
   const { data: orderList, isLoading } = useQuery({
@@ -60,7 +53,7 @@ export default function OrderList() {
   return (
     <>
       <BreadcrumbAndTitle />
-      <div className="flex w-[1140px] border-2 border-red-500 mb-24">
+      <div className="flex w-[1140px] border-2">
         <main className="flex-1">
           {isLoading ? (
             <div className="flex justify-center">
@@ -68,19 +61,15 @@ export default function OrderList() {
             </div>
           ) : (
             <>
-              {orderList?.map(
-                ({ orderAmount, orderDate, orderId, orderItemList }, idx) => {
-                  return (
-                    <OrderData
-                      key={idx}
-                      orderAmount={orderAmount}
-                      orderDate={orderDate}
-                      orderId={orderId}
-                      orderItemList={orderItemList}
-                    />
-                  );
-                }
-              )}
+              {orderList?.map(({ orderDate, orderItemList }, idx) => {
+                return (
+                  <OrderData
+                    key={idx}
+                    orderDate={orderDate}
+                    orderItemList={orderItemList}
+                  />
+                );
+              })}
             </>
           )}
         </main>

--- a/src/pages/OrderList/type.ts
+++ b/src/pages/OrderList/type.ts
@@ -8,9 +8,7 @@ interface IOrderItemListData {
 }
 
 export interface IOrderData {
-  orderAmount: number;
   orderDate: string;
-  orderId: number;
   orderItemList: IOrderItemListData[];
 }
 

--- a/src/pages/OrderList/type.ts
+++ b/src/pages/OrderList/type.ts
@@ -1,0 +1,17 @@
+import { AxiosResponse } from 'axios';
+
+interface IOrderItemListData {
+  itemCount: number;
+  itemId: number;
+  itemName: string;
+  totalPrice: number;
+}
+
+export interface IOrderData {
+  orderAmount: number;
+  orderDate: string;
+  orderId: number;
+  orderItemList: IOrderItemListData[];
+}
+
+export type OrderListResponse = AxiosResponse<IOrderData[]>;

--- a/src/pages/ProfilePage/OrderList/OrderList.tsx
+++ b/src/pages/ProfilePage/OrderList/OrderList.tsx
@@ -1,3 +1,64 @@
+import { useQuery } from '@tanstack/react-query';
+import { AxiosResponse } from 'axios';
+import { useEffect } from 'react';
+
+import { LOCAL_STORAGE_AUTH_TOKEN } from '@/constants/localStorageKey';
+import { API_AUTHORITY, API_ENDPOINT } from '@/services/apiEndpoint';
+import { axiosInstance } from '@/services/axiosInstance';
+
+interface IOrderItemListData {
+  itemCount: number;
+  itemId: number;
+  itemName: string;
+  totalPrice: number;
+}
+
+interface IOrderListData {
+  orderAmount: number;
+  orderDate: string;
+  orderId: number;
+  orderItemList: IOrderItemListData[];
+}
+
+type OrderListResponse = AxiosResponse<IOrderListData[]>;
+
+const DUMMY_SIDEBAR_DATA = [
+  { name: '프로필', url: '/profile' },
+  { name: '회원 정보 수정', url: '/profile/edit' },
+  { name: '로그아웃', url: '/logout' },
+];
+
 export default function OrderList() {
-  return <div>주문 내역을 확인하는 페이지</div>;
+  const getOrderList = async () => {
+    const token = localStorage.getItem(LOCAL_STORAGE_AUTH_TOKEN);
+
+    const res: OrderListResponse = await axiosInstance.get(
+      `${API_AUTHORITY.USER}${API_ENDPOINT.ORDER.ORDER_LIST}`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    );
+
+    return res.data;
+  };
+
+  const { data: orderList } = useQuery({
+    queryKey: ['orderList'],
+    queryFn: getOrderList,
+  });
+
+  useEffect(() => {
+    getOrderList();
+  }, []);
+
+  /**
+    구조의 경우, pr에 올라온 프로필 페이지
+
+    네모 규격: w: 750, h: 150
+    네모 디자인의 경우, orderPage 참고.
+   */
+
+  return <></>;
 }

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -8,5 +8,5 @@ export { default as PlantRecommend } from './MyPlantPage/PlantRecommend/PlantRec
 export { default as PlantRegister } from './MyPlantPage/PlantRegister/PlantRegister';
 export { default as NotFoundPage } from './NotFoundPage/NotFoundPage';
 export { default as OrderComplete } from './OrderComplete/OrderComplete';
+export { default as OrderList } from './OrderList/OrderList';
 export { default as ProfilePage } from './ProfilePage/MyPage';
-export { default as OrderList } from './ProfilePage/OrderList/OrderList';

--- a/src/services/apiEndpoint.ts
+++ b/src/services/apiEndpoint.ts
@@ -9,6 +9,7 @@ export const API_ENDPOINT = {
   ORDER: {
     LOOK_UP: '/order',
     CREATE: '/order/create',
+    ORDER_LIST: '/order/history',
   },
 };
 

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,0 +1,8 @@
+export const formatOrderDate = (string: string) => {
+  const date = new Date(string);
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+
+  return `${year}. ${month}. ${day}`;
+};


### PR DESCRIPTION
## 📝 설명
유저가 결제한 목록을 확인할 수 있는 주문 목록 페이지를 구현합니다.
<!-- PR에 대한 설명입니다. -->

## ✅ PR 유형

<!--
	팀원이 어떤 작업을 하였는지 쉽게 알아볼 수 있게 도와주는 부분입니다.
-->

- [x] 새로운 기능 추가


## 💻 작업 내용
- 주문 목록 페이지 구현
<!-- PR 본문을 입력하세요. -->

## 🎨 UI
<img width="1078" alt="스크린샷 2025-03-18 오전 9 45 13" src="https://github.com/user-attachments/assets/2dd36802-1392-4ea1-9320-a5b71876ab42" />

## 💬 PR 포인트
- 공통 컴포넌트 SideBar 의 수정이 필요할 것 같습니다.
props로 이동할 페이지를 받는 것이 아닌, SideBar 내부에 이동할 수 있는 페이지를 정의해야할 것 같습니다.
<!-- PR 리뷰 시 공유 사항 또는 유심히 보면 좋을 부분을 설명합니다. -->
