### PR TITLE
식물수정페이지 UI 구현

### DIFF
--- a/src/components/common/Breadcrumb/pathToTitles.ts
+++ b/src/components/common/Breadcrumb/pathToTitles.ts
@@ -10,5 +10,6 @@ export const PATH_TO_TITLES: Record<keyof typeof PATH, string> = {
   PLANT: '나의 식물 목록',
   PLANT_RECOMMEND: 'AI 식물 추천',
   PLANT_REGISTER: '식물 등록',
+  PLANT_MODIFY: '식물 수정',
   PLANT_DETAIL: '식물 성장',
 };

--- a/src/pages/Plant/PlantModify/GoalGrowthField.tsx
+++ b/src/pages/Plant/PlantModify/GoalGrowthField.tsx
@@ -1,0 +1,40 @@
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+interface GoalGrowthFieldProps {
+  value: number | null;
+  onChange: (e) => void;
+  onSearchClick: () => void;
+}
+/**
+ * GoalGrowthField
+ *
+ *  목표 성장치를 입력하거나 자동으로 추천받을 수 있는 입력 필드 컴포넌트입니다.
+ */
+export default function GoalGrowthField({
+  value,
+  onChange,
+  onSearchClick,
+}: GoalGrowthFieldProps) {
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <Label htmlFor="goalGrowth">목표 성장치</Label>
+        <Button
+          className="h-6"
+          onClick={onSearchClick}
+          type="button">
+          검색하기
+        </Button>
+      </div>
+      <Input
+        id="goalGrowth"
+        type="number"
+        onChange={onChange}
+        value={value ?? ''}
+        required
+      />
+    </div>
+  );
+}

--- a/src/pages/Plant/PlantModify/ImageDropZone.tsx
+++ b/src/pages/Plant/PlantModify/ImageDropZone.tsx
@@ -1,0 +1,47 @@
+import { Image } from 'lucide-react';
+
+interface ImageDropZoneProps {
+  onDragEnter: (e) => void;
+  onDragLeave: (e) => void;
+  onDragOver: (e) => void;
+  onDrop: (e) => void;
+  handleClick: (e) => void;
+  isDragging: boolean;
+}
+/**
+ * ImageDropZone
+ *
+ * 이미지 업로드 및 드래그 앤 드롭을 지원하는 컴포넌트입니다.
+ */
+export default function ImageDropZone({
+  onDragEnter,
+  onDragLeave,
+  onDragOver,
+  onDrop,
+  handleClick,
+  isDragging,
+}: ImageDropZoneProps) {
+  return (
+    <div
+      onDragEnter={onDragEnter}
+      onDragLeave={onDragLeave}
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+      className={`w-full h-40 border-2 rounded flex flex-col gap-2 items-center justify-center transition 
+                  ${isDragging ? 'border-blue-400 bg-blue-50' : 'border-gray-200'}`}>
+      <Image
+        className="w-10 h-10 "
+        strokeWidth={0.8}
+      />
+      <p>
+        <span
+          onClick={handleClick}
+          className="text-blue-400 cursor-pointer hover:underline">
+          이미지 업로드
+        </span>{' '}
+        또는 드래그 앤 드롭
+      </p>
+      <p>PNG, JPG, JPEG up to 10MB</p>
+    </div>
+  );
+}

--- a/src/pages/Plant/PlantModify/ImageDropZone.tsx
+++ b/src/pages/Plant/PlantModify/ImageDropZone.tsx
@@ -41,7 +41,7 @@ export default function ImageDropZone({
         </span>{' '}
         또는 드래그 앤 드롭
       </p>
-      <p>PNG, JPG, JPEG up to 10MB</p>
+      <p>PNG, JPG, JPEG, WEBP up to 10MB</p>
     </div>
   );
 }

--- a/src/pages/Plant/PlantModify/ImagePreview.tsx
+++ b/src/pages/Plant/PlantModify/ImagePreview.tsx
@@ -1,0 +1,24 @@
+import { X } from 'lucide-react';
+interface Props {
+  image: string;
+  onRemove: () => void;
+}
+/**
+ * ImagePreview
+ *
+ * 업로드된 이미지를 미리보기 형태로 보여주는 컴포넌트입니다.
+ */
+export default function ImagePreview({ image, onRemove }: Props) {
+  return (
+    <div className="relative border border-gray-200 rounded flex justify-center items-center p-6">
+      <img
+        src={image}
+        className="h-[15rem]"
+      />
+      <X
+        className="absolute top-3 right-3 cursor-pointer"
+        onClick={onRemove}
+      />
+    </div>
+  );
+}

--- a/src/pages/Plant/PlantModify/InputField.tsx
+++ b/src/pages/Plant/PlantModify/InputField.tsx
@@ -1,0 +1,39 @@
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+interface InputFieldProps {
+  id: string;
+  label: string;
+  type: string;
+  min?: number;
+  max?: number;
+  step?: number;
+  required?: boolean;
+  onChange?: (e) => void;
+}
+
+export default function InputField({
+  id,
+  label,
+  type,
+  min,
+  max,
+  step,
+  required = false,
+  onChange,
+}: InputFieldProps) {
+  return (
+    <div className="flex flex-col gap-2">
+      <Label htmlFor={id}>{label}</Label>
+      <Input
+        id={id}
+        type={type}
+        min={min}
+        max={max}
+        step={step}
+        required={required}
+        onChange={onChange}
+      />
+    </div>
+  );
+}

--- a/src/pages/Plant/PlantModify/PlantModify.tsx
+++ b/src/pages/Plant/PlantModify/PlantModify.tsx
@@ -1,0 +1,162 @@
+import { useRef, useState } from 'react';
+import { toast } from 'react-toastify';
+
+import BreadcrumbAndTitle from '@/components/common/Breadcrumb/BreadcrumbAndTitle';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+import { INPUT_FIELDS } from './constants/InputFields';
+import { VALID_EXTENSIONS } from './constants/validExtensions';
+import GoalGrowthField from './GoalGrowthField';
+import ImageDropZone from './ImageDropZone';
+import ImagePreview from './ImagePreview';
+import InputField from './InputField';
+import { IPlantRegister } from './types';
+
+/**
+ * PlantRegister
+ *
+ * 사용자가 식물 품종을 등록할 수 있는 폼을 제공합니다.
+ */
+export default function PlantModify() {
+  const fileRef = useRef<HTMLInputElement>(null);
+  const [state, setState] = useState<IPlantRegister>({
+    plantName: '',
+    temperature: null,
+    humidity: null,
+    light: null,
+    soilMoisture: null,
+    goalGrowth: null,
+    image: null,
+  });
+  const [isDragging, setIsDragging] = useState(false);
+
+  const handleClick = () => {
+    fileRef.current.click();
+  };
+
+  const isValidImageFile = (file: File) => {
+    const extension = file.name.split('.').pop();
+    return extension && VALID_EXTENSIONS.includes(extension);
+  };
+
+  const handleFileUpload = (file: File) => {
+    if (!isValidImageFile(file)) {
+      toast.error('PNG, JPG, JPEG 형식의 파일만 업로드 가능합니다.');
+      return;
+    } else if (file.size > 10 * 1024 * 1024) {
+      toast.error(`파일 크기는 10MB 이하로 업로드해주세요.`);
+      return;
+    }
+
+    const imageUrl = URL.createObjectURL(file);
+    setState(prev => ({ ...prev, image: imageUrl }));
+  };
+
+  const handleFileChange = e => {
+    const file = e.target.files[0];
+    if (!file) return;
+    handleFileUpload(file);
+  };
+
+  const handleChange = e => {
+    const { id, value } = e.target;
+    setState(prev => ({ ...prev, [id]: value }));
+  };
+
+  const handleDrop = e => {
+    e.preventDefault();
+    setIsDragging(false);
+    const file = e.dataTransfer.files[0];
+    handleFileUpload(file);
+  };
+
+  const handleGoalGrowthSearch = () => {
+    // TODO: chatgpt api 연결해서 목표 성장치 검색하기
+    //! mockData로 100설정
+    setState(prev => ({ ...prev, goalGrowth: 100 }));
+  };
+
+  const handleSubmit = e => {
+    e.preventDefault();
+    // TODO: API 연결하여 등록 값 전달해야 함
+    console.log('state', state);
+  };
+
+  return (
+    <>
+      {/* 상단 타이틀 및 Breadcrumb */}
+      <BreadcrumbAndTitle />
+      <main className="w-full max-w-[1140px] mb-20 px-5 md:px-0">
+        <form onSubmit={handleSubmit}>
+          {/*이미지 업로드 섹션*/}
+          <div className="w-full max-w-[40rem] h-auto border border-gray-200 p-6 rounded mb-4 flex flex-col gap-4">
+            <h1 className="font-bold">이미지 업로드</h1>
+            {state.image ? (
+              <ImagePreview
+                image={state.image}
+                onRemove={() => {
+                  setState(prev => ({ ...prev, image: null }));
+                }}
+              />
+            ) : (
+              <ImageDropZone
+                onDragEnter={() => {
+                  setIsDragging(true);
+                }}
+                onDragLeave={() => {
+                  setIsDragging(false);
+                }}
+                onDragOver={e => {
+                  e.preventDefault();
+                }}
+                onDrop={handleDrop}
+                handleClick={handleClick}
+                isDragging={isDragging}
+              />
+            )}
+            <Input
+              id="input-file"
+              ref={fileRef}
+              className="hidden"
+              type="file"
+              onChange={handleFileChange}
+            />
+          </div>
+
+          {/*품종 등록 섹션*/}
+          <div className="border border-gray-200 p-6 rounded flex flex-col gap-4 w-full max-w-[40rem]">
+            <h1 className="font-bold">품종 등록</h1>
+            {/* 품종명, 온도, 습도, 광량, 토양습도 입력 필드 */}
+            {INPUT_FIELDS.map(field => (
+              <InputField
+                key={field.id}
+                id={field.id}
+                label={field.label}
+                type={field.type}
+                step={field.step}
+                min={field.min}
+                max={field.max}
+                onChange={handleChange}
+                required={field.required}
+              />
+            ))}
+
+            {/*목표 성장치 입력 필드*/}
+            <GoalGrowthField
+              value={state.goalGrowth}
+              onChange={handleChange}
+              onSearchClick={handleGoalGrowthSearch}
+            />
+          </div>
+
+          <Button
+            type="submit"
+            className="mt-4">
+            품종 등록
+          </Button>
+        </form>
+      </main>
+    </>
+  );
+}

--- a/src/pages/Plant/PlantModify/PlantModify.tsx
+++ b/src/pages/Plant/PlantModify/PlantModify.tsx
@@ -35,7 +35,7 @@ export default function PlantModify() {
   const handleBack = () => {
     navigate(-1);
   };
-  const handleClick = () => {
+  const handleImageUploadClick = () => {
     fileRef.current.click();
   };
 
@@ -115,7 +115,7 @@ export default function PlantModify() {
                   e.preventDefault();
                 }}
                 onDrop={handleDrop}
-                handleClick={handleClick}
+                handleClick={handleImageUploadClick}
                 isDragging={isDragging}
               />
             )}

--- a/src/pages/Plant/PlantModify/PlantModify.tsx
+++ b/src/pages/Plant/PlantModify/PlantModify.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
 
 import BreadcrumbAndTitle from '@/components/common/Breadcrumb/BreadcrumbAndTitle';
@@ -12,11 +13,10 @@ import ImageDropZone from './ImageDropZone';
 import ImagePreview from './ImagePreview';
 import InputField from './InputField';
 import { IPlantRegister } from './types';
-
 /**
- * PlantRegister
+ * PlantModify.tsx
  *
- * 사용자가 식물 품종을 등록할 수 있는 폼을 제공합니다.
+ * 사용자가 식물 품종을 수정할 수 있는 폼을 제공합니다.
  */
 export default function PlantModify() {
   const fileRef = useRef<HTMLInputElement>(null);
@@ -29,8 +29,12 @@ export default function PlantModify() {
     goalGrowth: null,
     image: null,
   });
-  const [isDragging, setIsDragging] = useState(false);
+  const [isDragging, setIsDragging] = useState<boolean>(false);
+  const navigate = useNavigate();
 
+  const handleBack = () => {
+    navigate(-1);
+  };
   const handleClick = () => {
     fileRef.current.click();
   };
@@ -79,7 +83,7 @@ export default function PlantModify() {
 
   const handleSubmit = e => {
     e.preventDefault();
-    // TODO: API 연결하여 등록 값 전달해야 함
+    // TODO: API 연결하여 수정 값 전달해야 함
     console.log('state', state);
   };
 
@@ -150,11 +154,15 @@ export default function PlantModify() {
             />
           </div>
 
-          <Button
-            type="submit"
-            className="mt-4">
-            품종 등록
-          </Button>
+          <div className="flex justify-between max-w-[40rem] mt-4">
+            <Button
+              type="button"
+              onClick={handleBack}
+              className="bg-gray-400 hover:bg-gray-300">
+              뒤로 가기
+            </Button>
+            <Button type="submit">품종 등록</Button>
+          </div>
         </form>
       </main>
     </>

--- a/src/pages/Plant/PlantModify/PlantModify.tsx
+++ b/src/pages/Plant/PlantModify/PlantModify.tsx
@@ -46,7 +46,7 @@ export default function PlantModify() {
 
   const handleFileUpload = (file: File) => {
     if (!isValidImageFile(file)) {
-      toast.error('PNG, JPG, JPEG 형식의 파일만 업로드 가능합니다.');
+      toast.error('PNG, JPG, JPEG, WEBP 형식의 파일만 업로드 가능합니다.');
       return;
     } else if (file.size > 10 * 1024 * 1024) {
       toast.error(`파일 크기는 10MB 이하로 업로드해주세요.`);

--- a/src/pages/Plant/PlantModify/constants/InputFields.ts
+++ b/src/pages/Plant/PlantModify/constants/InputFields.ts
@@ -1,0 +1,27 @@
+export const INPUT_FIELDS = [
+  { id: 'plantName', label: '품종명', type: 'text', required: true },
+  {
+    id: 'temperature',
+    label: '온도(°C)',
+    type: 'number',
+    step: 0.1,
+    required: true,
+  },
+  {
+    id: 'humidity',
+    label: '습도(%)',
+    type: 'number',
+    min: 0,
+    max: 100,
+    required: true,
+  },
+  { id: 'light', label: '광량(lux)', type: 'number', min: 0, required: true },
+  {
+    id: 'soilMoisture',
+    label: '토양습도(%)',
+    type: 'number',
+    min: 0,
+    max: 100,
+    required: true,
+  },
+];

--- a/src/pages/Plant/PlantModify/constants/validExtensions.ts
+++ b/src/pages/Plant/PlantModify/constants/validExtensions.ts
@@ -1,0 +1,1 @@
+export const VALID_EXTENSIONS = ['png', 'jpg', 'jpeg'];

--- a/src/pages/Plant/PlantModify/constants/validExtensions.ts
+++ b/src/pages/Plant/PlantModify/constants/validExtensions.ts
@@ -1,1 +1,1 @@
-export const VALID_EXTENSIONS = ['png', 'jpg', 'jpeg'];
+export const VALID_EXTENSIONS = ['png', 'jpg', 'jpeg', 'webp'];

--- a/src/pages/Plant/PlantModify/types.ts
+++ b/src/pages/Plant/PlantModify/types.ts
@@ -1,0 +1,9 @@
+export interface IPlantRegister {
+  plantName: string;
+  temperature: number | null;
+  humidity: number | null;
+  light: number | null;
+  soilMoisture: number | null;
+  goalGrowth: number | null;
+  image: string | null;
+}

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -12,4 +12,5 @@ export { default as PlantRecommend } from './Plant/AIRecommend/AIRecommend';
 export { default as MyPlantPage } from './Plant/MyPlantPage/MyPlantPage';
 export { default as PlantDetail } from './Plant/PlantDetail/PlantDetail';
 export { default as PlantDictionary } from './Plant/PlantDictionary/PlantDictionary';
+export { default as PlantModify } from './Plant/PlantModify/PlantModify';
 export { default as PlantRegister } from './Plant/PlantRegister/PlantRegister';

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -13,6 +13,7 @@ import {
   PasswordChange,
   PlantDetail,
   PlantDictionary,
+  PlantModify,
   PlantRecommend,
   PlantRegister,
   ProfilePage,
@@ -73,11 +74,10 @@ export function AppRoutes() {
             path={PATH.PLANT_REGISTER}
             element={<PrivateRoute page={<PlantRegister />} />}
           />
-          {/* 내 식물 수정 추가 예정 */}
-          {/* <Route
+          <Route
             path={PATH.PLANT_MODIFY}
-            element={<PrivateRoute page={< />} />}
-          /> */}
+            element={<PrivateRoute page={<PlantModify />} />}
+          />
           <Route
             path={PATH.PLANT_DETAIL}
             element={<PrivateRoute page={<PlantDetail />} />}


### PR DESCRIPTION
## 📝 설명
식물 수정 페이지 UI 구현
<!-- PR에 대한 설명입니다. -->

## ✅ PR 유형

<!--
	팀원이 어떤 작업을 하였는지 쉽게 알아볼 수 있게 도와주는 부분입니다.
-->

- [x] CSS 등 사용자 UI 디자인 구현


## 💻 작업 내용
- 식물 수정 페이지를 라우트에 추가했습니다.
- Breadcrumb와 페이지 타이틀 설정을 위해 PATH_TO_TITLES에 식물 수정 페이지 정보를 추가했습니다.
- 식물 수정 페이지 UI 구현했습니다.

## 🎨UI
![image](https://github.com/user-attachments/assets/d0e8f50b-6177-432b-b8e4-5ce856fa7991)


## 💬 PR 포인트
식물 등록 페이지와 식물 수정 페이지가 코드가 동일합니다!
식물 등록 페이지에 먼저 리뷰 남겨주시면 반영해서 식물 수정 페이지도 수정하겠습니다!
<!-- PR 리뷰 시 공유 사항 또는 유심히 보면 좋을 부분을 설명합니다. -->
