### PR TITLE
plantRegister페이지 파일 확장자 webp도 업로드 가능하도록 수정

### DIFF
--- a/src/pages/Plant/PlantRegister/ImageDropZone.tsx
+++ b/src/pages/Plant/PlantRegister/ImageDropZone.tsx
@@ -41,7 +41,7 @@ export default function ImageDropZone({
         </span>{' '}
         또는 드래그 앤 드롭
       </p>
-      <p>PNG, JPG, JPEG up to 10MB</p>
+      <p>PNG, JPG, JPEG, WEBP up to 10MB</p>
     </div>
   );
 }

--- a/src/pages/Plant/PlantRegister/PlantRegister.tsx
+++ b/src/pages/Plant/PlantRegister/PlantRegister.tsx
@@ -48,7 +48,7 @@ export default function PlantRegister() {
 
   const handleFileUpload = (file: File) => {
     if (!isValidImageFile(file)) {
-      toast.error('PNG, JPG, JPEG 형식의 파일만 업로드 가능합니다.');
+      toast.error('PNG, JPG, JPEG, WEBP 형식의 파일만 업로드 가능합니다.');
       return;
     } else if (file.size > 10 * 1024 * 1024) {
       toast.error(`파일 크기는 10MB 이하로 업로드해주세요.`);

--- a/src/pages/Plant/PlantRegister/constants/validExtensions.ts
+++ b/src/pages/Plant/PlantRegister/constants/validExtensions.ts
@@ -1,1 +1,1 @@
-export const VALID_EXTENSIONS = ['png', 'jpg', 'jpeg'];
+export const VALID_EXTENSIONS = ['png', 'jpg', 'jpeg', 'webp'];


### PR DESCRIPTION
## 📝 설명
plantRegister페이지에서 파일 업로드 할 때, 파일 확장자가 webp여도 업로드 가능하도록 수정하였습니다.
저번 plantRegister pr에서 수정하지 못하고 머지해버려서 다시 한 번 올립니다. 
## ✅ PR 유형

<!--
	팀원이 어떤 작업을 하였는지 쉽게 알아볼 수 있게 도와주는 부분입니다.
-->

- [x] CSS 등 사용자 UI 디자인 변경

## 💻 작업 내용
- 파일 업로드 시 확장자가 webp 일 경우에 오류 처리되지 않고 업로드 되도록 변경하였습니다.

<!-- PR 본문을 입력하세요. -->

## 💬 PR 포인트

<!-- PR 리뷰 시 공유 사항 또는 유심히 보면 좋을 부분을 설명합니다. -->
