### PR TITLE
식물 라우팅 수정

### DIFF
--- a/src/constants/header.ts
+++ b/src/constants/header.ts
@@ -9,7 +9,7 @@ export const MENU_ITEMS = [
 
 export const NAME_TO_PATH = {
   '키트 정보': '/product',
-  '나의 식물': '/plant/myPlant',
+  '나의 식물': '/plant',
   '식물 지식백과': '/plant/dictionary',
   'AI 식물 추천': '/plant/AIRecommend',
   '내 정보': '/profile',

--- a/src/constants/header.ts
+++ b/src/constants/header.ts
@@ -1,5 +1,7 @@
 import { CircleHelp, CircleUserRound } from 'lucide-react';
 
+import { PATH } from '@/routes/path';
+
 export const MENU_ITEMS = [
   '키트 정보',
   '나의 식물',
@@ -8,14 +10,14 @@ export const MENU_ITEMS = [
 ];
 
 export const NAME_TO_PATH = {
-  '키트 정보': '/product',
-  '나의 식물': '/plant',
-  '식물 지식백과': '/plant/dictionary',
-  'AI 식물 추천': '/plant/AIRecommend',
-  '내 정보': '/profile',
-  '고객 센터': '/customer-center',
-  '로그인/로그아웃': '/sign',
-};
+  '키트 정보': PATH.PRODUCT,
+  '나의 식물': PATH.PLANT,
+  '식물 지식백과': `${PATH.PLANT}/${PATH.PLANT_DICTIONARY}`,
+  'AI 식물 추천': `${PATH.PLANT}/${PATH.PLANT_RECOMMEND}`,
+  '내 정보': PATH.PROFILE,
+  '고객 센터': PATH.CUSTOMER_CENTER,
+  '로그인/로그아웃': PATH.SIGN,
+} as const;
 
 export const ADDITIONAL_MENU_ITEMS = [
   '고객 센터',

--- a/src/pages/Plant/PlantDetail/PlantDetail.tsx
+++ b/src/pages/Plant/PlantDetail/PlantDetail.tsx
@@ -1,3 +1,0 @@
-export default function PlantDetail() {
-  return <div>나의 식물 : 진달래</div>;
-}

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -10,7 +10,6 @@ export { default as ProfilePage } from './MyPage/ProfilePage/ProfilePage';
 export { default as NotFoundPage } from './NotFoundPage/NotFoundPage';
 export { default as PlantRecommend } from './Plant/AIRecommend/AIRecommend';
 export { default as MyPlantPage } from './Plant/MyPlantPage/MyPlantPage';
-export { default as PlantDetail } from './Plant/PlantDetail/PlantDetail';
 export { default as PlantDiary } from './Plant/PlantDiary/PlantDiary';
 export { default as PlantDictionary } from './Plant/PlantDictionary/PlantDictionary';
 export { default as PlantModify } from './Plant/PlantModify/PlantModify';

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -76,10 +76,6 @@ export function AppRoutes() {
             element={<PrivateRoute page={<PlantDiary />} />}
           />
           <Route
-            path={PATH.PLANT_DIARY}
-            element={<PrivateRoute page={<PlantDiary />} />}
-          />
-          <Route
             path={PATH.PLANT_REGISTER}
             element={<PrivateRoute page={<PlantRegister />} />}
           />

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -68,11 +68,11 @@ export function AppRoutes() {
         {/* 식물 페이지 */}
         <Route path={PATH.PLANT}>
           <Route
-            path={PATH.PLANT_MY_PLANT}
+            index
             element={<PrivateRoute page={<MyPlantPage />} />}
           />
           <Route
-            path={`${PATH.PLANT_MY_PLANT}/${PATH.PLANT_DIARY}/:id`}
+            path={`${PATH.PLANT_DIARY}/:id`}
             element={<PrivateRoute page={<PlantDiary />} />}
           />
           <Route

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -11,7 +11,6 @@ import {
   OrderComplete,
   OrderList,
   PasswordChange,
-  PlantDetail,
   PlantDiary,
   PlantDictionary,
   PlantModify,
@@ -82,10 +81,6 @@ export function AppRoutes() {
           <Route
             path={PATH.PLANT_MODIFY}
             element={<PrivateRoute page={<PlantModify />} />}
-          />
-          <Route
-            path={PATH.PLANT_DETAIL}
-            element={<PrivateRoute page={<PlantDetail />} />}
           />
           <Route
             path={PATH.PLANT_DICTIONARY}

--- a/src/routes/path.ts
+++ b/src/routes/path.ts
@@ -18,7 +18,6 @@ export const PATH: IPath = {
 
   // Plant
   PLANT: '/plant',
-  PLANT_MY_PLANT: 'myPlant',
   PLANT_REGISTER: 'register',
   PLANT_MODIFY: 'modify',
   PLANT_DETAIL: 'detail',


### PR DESCRIPTION
## 📝 설명
식물 카테고리의 페이지들의 라우팅 경로명을 적절하게 수정하였습니다.
<!-- PR에 대한 설명입니다. -->

## ✅ PR 유형

<!--
	팀원이 어떤 작업을 하였는지 쉽게 알아볼 수 있게 도와주는 부분입니다.
-->

- [x] 파일 혹은 폴더명 수정 / 삭제


## 💻 작업 내용
- 기존 주소들을 아래와 같이 수정합니다.
  - domain/plant => index, 내 식물 목록 페이지
  - domain/plant/register => 식물 등록 페이지
  - domain/plant/AIRecomend => ai 식물 추천 페이지
  - ...
<!-- PR 본문을 입력하세요. -->

## 💬 PR 포인트

<!-- PR 리뷰 시 공유 사항 또는 유심히 보면 좋을 부분을 설명합니다. -->
